### PR TITLE
Fix import error: static => fanstatic

### DIFF
--- a/kotti_software/__init__.py
+++ b/kotti_software/__init__.py
@@ -4,7 +4,7 @@ from fanstatic import (
     Group,
     )
 from pyramid.i18n import TranslationStringFactory
-from kotti.static import view_needed
+from kotti.fanstatic import view_needed
 from kotti.util import extract_from_settings
 from js.jquery_infinite_ajax_scroll import (
     jquery_infinite_ajax_scroll,


### PR DESCRIPTION
Without this, I get the following error with Kotti from git master:

``` pytb
      File "/Users/marca/python/virtualenvs/kotti_inventorysvc/lib/python2.7/site-packages/kotti_software/__init__.py", line 7, in <module>
        from kotti.static import view_needed
    ImportError: No module named static
```

```
[marca@marca-mac2 ~VIRTUAL_ENV]$ pip freeze 2> /dev/null | grep Kotti
-e git+git@github.com:Kotti/Kotti.git@d1ff5594bf9ec05e20f68c2343fb12278fc47f6b#egg=Kotti-master
```
